### PR TITLE
Fix always empty product categories and tags

### DIFF
--- a/cocart-get-cart-enhanced.php
+++ b/cocart-get-cart-enhanced.php
@@ -74,10 +74,10 @@ if ( ! class_exists( 'CoCart_Get_Cart_Enhanced' ) ) {
 			$cart_contents[ $item_key ]['product_type'] = $_product->get_type();
 
 			// Returns the product categories.
-			$cart_contents[ $item_key ]['categories'] = get_the_terms( $_product->get_category_ids(), 'product_cat' );
+			$cart_contents[ $item_key ]['categories'] = get_the_terms( $_product->get_id(), 'product_cat' );
 
 			// Returns the product tags.
-			$cart_contents[ $item_key ]['tags'] = get_the_terms( $_product->get_tag_ids(), 'product_tag' );
+			$cart_contents[ $item_key ]['tags'] = get_the_terms( $_product->get_id(), 'product_tag' );
 
 			// Returns the product SKU.
 			$cart_contents[ $item_key ]['sku'] = $_product->get_sku();


### PR DESCRIPTION
The enhanced product details returns always `false` for categories and tags because the function `get_the_terms` requires the post/product ID.